### PR TITLE
fix: validate displayname when not available

### DIFF
--- a/django_firebase_auth/firebase_auth.py
+++ b/django_firebase_auth/firebase_auth.py
@@ -97,7 +97,8 @@ class FirebaseAuthentication(authentication.BaseAuthentication):
             return None
 
         striped_user_name = decoded_token["email"].split("@")[0]
-        first_name, last_name = self.convert_user_display_name(decoded_token["name"])
+        display_name = decoded_token.get('name', striped_user_name)
+        first_name, last_name = self.convert_user_display_name(display_name)
         user: User = User.objects.get_or_create(
             email=decoded_token.get("email"),
             defaults={
@@ -132,5 +133,7 @@ class FirebaseAuthentication(authentication.BaseAuthentication):
         last_name(str): last name of user
         """
         first_name = display_name.split(" ")[0]
-        last_name = display_name.split(" ")[1]
+        last_name = None
+        if len(display_name)>1:
+            last_name = display_name.split(" ")[1]
         return first_name, last_name

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-firebase-auth',
-    version="1.0.4",
+    version="1.0.5",
     packages=find_packages(),
     install_requires=[
         'firebase-admin',


### PR DESCRIPTION
When creating the user via email and password on firebase, the user is by default with no displayname, this validates that and defaults to the email stripped username


- Also, better handling if the header is not present