### PR TITLE
fix: raise excpt when header not present

### DIFF
--- a/django_firebase_auth/firebase_auth.py
+++ b/django_firebase_auth/firebase_auth.py
@@ -73,7 +73,7 @@ class FirebaseAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
         auth_header = request.META.get("HTTP_AUTHORIZATION")
         if not auth_header:
-            return None
+            raise InvalidAuthToken("Authorization header not present")
         host = request.get_host()
         if host.startswith("localhost") and not auth_header.startswith("Bearer ") and DEBUG:
             return User.objects.get(username=auth_header), None

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-firebase-auth',
-    version="1.0.5",
+    version="1.0.6",
     packages=find_packages(),
     install_requires=[
         'firebase-admin',


### PR DESCRIPTION
Raise excpt when header not present.

returning None was not a good fit given that the sucessful execution of the method returns a tuple.